### PR TITLE
Simplify service registration

### DIFF
--- a/JssSnippet/App_Config/Include/Foundation/JssSnippet.Foundation.Extensions.LayoutService.config
+++ b/JssSnippet/App_Config/Include/Foundation/JssSnippet.Foundation.Extensions.LayoutService.config
@@ -1,8 +1,8 @@
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore>
 		<services>
-			<configurator type="Sitecore.LayoutService.RegisterDependencies, Sitecore.LayoutService">
-				<patch:attribute name="type">JssSnippet.Configurators.RegisterDependencies, JssSnippet</patch:attribute>
+			<configurator type="JssSnippet.Configurators.RegisterDependencies, JssSnippet">
+				<patch:after>Sitecore.LayoutService.RegisterDependencies, Sitecore.LayoutService</patch:after>
 			</configurator>
 		</services>
 	</sitecore>

--- a/JssSnippet/Configurators/RegisterDependencies.cs
+++ b/JssSnippet/Configurators/RegisterDependencies.cs
@@ -1,12 +1,8 @@
 ﻿using JssSnippet.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Sitecore.DependencyInjection;
-using Sitecore.LayoutService.Configuration;
 using Sitecore.LayoutService.ItemRendering;
-using Sitecore.LayoutService.ItemRendering.Pipelines.GetLayoutServiceContext;
-using Sitecore.LayoutService.Presentation.Pipelines.RenderJsonRendering;
-using Sitecore.LayoutService.Serialization;
-using Sitecore.LayoutService.Serialization.Pipelines.GetFieldSerializer;
 
 namespace JssSnippet.Configurators
 {
@@ -14,15 +10,7 @@ namespace JssSnippet.Configurators
     {
         public void Configure(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddSingleton<IConfiguration, Configuration>();
-            serviceCollection.AddSingleton<IFieldRenderer, FieldRenderer>();
-            serviceCollection.AddSingleton<ISerializerService, SerializerService>();
-            serviceCollection.AddSingleton<IRenderJsonRenderingPipeline, RenderJsonRenderingPipeline>();
-            serviceCollection.AddSingleton<IGetFieldSerializerPipeline, GetFieldSerializerPipeline>();
-            serviceCollection.AddSingleton<IPlaceholderRenderingService, PlaceholderRenderingService>();
-            serviceCollection.AddSingleton<ILayoutServiceContext, PipelineLayoutServiceContext>();
-            serviceCollection.AddSingleton<IGetLayoutServiceContextPipeline, GetLayoutServiceContextPipeline>();
-            serviceCollection.AddSingleton<ILayoutService, CustomLayoutService>();
+            serviceCollection.Replace(ServiceDescriptor.Singleton<ILayoutService, CustomLayoutService>());
         }
     }
 }


### PR DESCRIPTION
Register only the `CustomLayoutService` with the container without duplicating and replacing the default Layout Service configurator.